### PR TITLE
feat: scaffold photos carousel monorepo

### DIFF
--- a/photos-carousel/.eslintrc.cjs
+++ b/photos-carousel/.eslintrc.cjs
@@ -1,0 +1,38 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true,
+    node: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:react/recommended',
+    'plugin:jsx-a11y/recommended',
+    'prettier'
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  plugins: ['@typescript-eslint', 'react', 'jsx-a11y'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': 'off'
+      }
+    }
+  ]
+};

--- a/photos-carousel/.gitignore
+++ b/photos-carousel/.gitignore
@@ -1,0 +1,15 @@
+node_modules
+.pnpm-store
+.dist
+build
+coverage
+.DS_Store
+.env
+.env.*
+pnpm-lock.yaml
+apps/web/dist
+apps/server/dist
+apps/web/.turbo
+apps/web/.vite
+apps/web/node_modules
+apps/server/node_modules

--- a/photos-carousel/.prettierrc
+++ b/photos-carousel/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/photos-carousel/README.md
+++ b/photos-carousel/README.md
@@ -1,0 +1,113 @@
+# Photos Carousel
+
+Carrusel fotográfico para tablet Android usando Google Photos Picker y control por Model Context Protocol.
+
+## Estructura del monorepo
+
+```
+/photos-carousel
+  /apps
+    /web      → PWA React 18 + Vite + Tailwind + Zustand
+    /server   → Express + MCP server
+  /packages
+    /types    → Tipos y schemas Zod compartidos
+    /ui       → Componentes reutilizables
+```
+
+## Requisitos
+
+- Node.js 20
+- pnpm 8.15+
+- Google Cloud project con Photos Picker API habilitada
+
+## Variables de entorno
+
+Crea un archivo `.env` en `apps/server` con:
+
+```
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback
+GOOGLE_ALLOWED_ORIGIN=http://localhost:5173
+SESSION_SECRET=cambia-esto
+```
+
+## Desarrollo
+
+```bash
+cd photos-carousel
+pnpm install
+pnpm dev:server
+pnpm dev:web
+```
+
+- Web: http://localhost:5173
+- API: http://localhost:3000 (por defecto)
+
+## Tests y calidad
+
+```bash
+pnpm lint
+pnpm test
+pnpm --filter @photos-carousel/web test:ui
+```
+
+## Despliegue
+
+1. **Frontend**: Ejecuta `pnpm --filter @photos-carousel/web build` y despliega `apps/web/dist` en Vercel/Netlify.
+2. **Backend**: Construye la imagen Docker (`docker build -t photos-carousel apps/server`) y despliega en Fly.io, Render o Cloud Run. Expone `/api` con HTTPS.
+3. Configura CORS para permitir únicamente el origin de la PWA.
+4. Sube variables OAuth en el proveedor (client id/secret, redirect URI).
+
+## Google Cloud setup
+
+1. Crea proyecto.
+2. Habilita **Google Photos Library API** y **Google Photos Picker API**.
+3. Configura pantalla de consentimiento OAuth con los scopes mínimos:
+   - `https://www.googleapis.com/auth/photospicker.mediaitems.readonly`
+4. Crea credenciales OAuth 2.0 (tipo aplicación web). Define redirect URI del servidor.
+5. Descarga el JSON y coloca client_id/client_secret en `.env`.
+
+## MCP
+
+El servidor expone herramientas MCP in-process. Para conectarlo con un LLM:
+
+```bash
+node apps/server/dist/index.js --mcp-stdio
+```
+
+Define las herramientas registradas: `open_picker`, `poll_session`, `list_media_items`, `get_image_blob`, `slideshow_control`.
+
+## Bubblewrap / Trusted Web Activity
+
+1. Instala Bubblewrap (`npm i -g @bubblewrap/cli`).
+2. Ejecuta `pnpm --filter @photos-carousel/web run build`.
+3. `pnpm run twa:init` (script pendiente) inicializa proyecto TWA con nombre, iconos e intent filter para HTTPS.
+4. Sube el asset link a tu dominio para asociar la app.
+
+## API Endpoints
+
+- `POST /auth/login`
+- `GET /auth/callback`
+- `POST /picker/session`
+- `GET /picker/session/:id`
+- `GET /media?sessionId`
+- `GET /media/:id/content`
+- `POST /slideshow/control`
+- `POST /filters/apply` (en frontend)
+- `POST /llm/command`
+
+Consulta `packages/types` para los schemas exactos.
+
+## Notas de seguridad
+
+- Cookies httpOnly + SameSite=Lax.
+- Rate limit en `/picker/*` y `/media/*`.
+- Base URLs de Google expiran en ~60 min (ver constantes en `@photos-carousel/types`).
+- IndexedDB guarda blobs máximo 200 MB y se renueva cada 55 min.
+
+## Roadmap
+
+- Integrar OAuth Authorization Code + PKCE real.
+- Implementar fetch autenticado a Google Photos Picker API.
+- Añadir soporte wake lock y métricas Web Vitals.

--- a/photos-carousel/apps/server/Dockerfile
+++ b/photos-carousel/apps/server/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-alpine as builder
+WORKDIR /app
+COPY ../../package.json ../../pnpm-workspace.yaml ../../tsconfig.base.json ../../tsconfig.json ./
+COPY ../../packages ./packages
+COPY . ./apps/server
+RUN npm install -g pnpm@8.15.4
+RUN pnpm install --frozen-lockfile || pnpm install
+RUN pnpm --filter @photos-carousel/server build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/apps/server/dist ./dist
+COPY --from=builder /app/apps/server/package.json ./package.json
+COPY --from=builder /app/apps/server/node_modules ./node_modules
+ENV NODE_ENV=production
+CMD ["node", "dist/index.js"]

--- a/photos-carousel/apps/server/package.json
+++ b/photos-carousel/apps/server/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@photos-carousel/server",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -b",
+    "start": "node dist/index.js",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "test": "vitest run",
+    "format": "prettier --write 'src/**/*.{ts,tsx}'"
+  },
+  "dependencies": {
+    "@google-cloud/local-auth": "^2.4.0",
+    "@modelcontextprotocol/sdk": "^0.1.0",
+    "@photos-carousel/types": "workspace:^",
+    "axios": "^1.6.7",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2",
+    "express-rate-limit": "^7.1.5",
+    "express-session": "^1.17.3",
+    "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.2",
+    "node-fetch": "^3.3.2",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/express-session": "^1.17.8",
+    "@types/node": "^20.11.30",
+    "@types/cors": "^2.8.17",
+    "@types/jsonwebtoken": "^9.0.5",
+    "@types/node-fetch": "^2.6.4",
+    "@types/supertest": "^2.0.16",
+    "supertest": "^6.3.3",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  }
+}

--- a/photos-carousel/apps/server/src/__tests__/app.test.ts
+++ b/photos-carousel/apps/server/src/__tests__/app.test.ts
@@ -1,0 +1,21 @@
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { app } from '../app.js';
+
+describe('server routes', () => {
+  it('creates picker sessions', async () => {
+    const response = await request(app).post('/picker/session').send({});
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('sessionId');
+  });
+
+  it('lists media items after session ready', async () => {
+    const session = await request(app).post('/picker/session').send({});
+    expect(session.status).toBe(200);
+    const sessionId = session.body.sessionId;
+    await new Promise((resolve) => setTimeout(resolve, 3100));
+    const list = await request(app).get('/media').query({ sessionId });
+    expect(list.status).toBe(200);
+    expect(Array.isArray(list.body.items)).toBe(true);
+  });
+});

--- a/photos-carousel/apps/server/src/__tests__/mcp.test.ts
+++ b/photos-carousel/apps/server/src/__tests__/mcp.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { mcpServer } from '../services/mcp-server.js';
+
+const server: any = mcpServer;
+
+describe('MCP server tools', () => {
+  it('registers and resolves tools', async () => {
+    const tool = server.getTool('open_picker');
+    expect(tool).toBeTypeOf('function');
+    const result = await tool({});
+    expect(result).toHaveProperty('sessionId');
+  });
+});

--- a/photos-carousel/apps/server/src/app.ts
+++ b/photos-carousel/apps/server/src/app.ts
@@ -1,0 +1,57 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import session from 'express-session';
+import rateLimit from 'express-rate-limit';
+import { oauthConfig } from './config/env.js';
+import { pickerRouter } from './routes/picker.js';
+import { mediaRouter } from './routes/media.js';
+import { slideshowRouter } from './routes/slideshow.js';
+import { llmRouter } from './routes/llm.js';
+import { authRouter } from './routes/auth.js';
+
+const app = express();
+
+app.set('trust proxy', 1);
+app.use(helmet());
+app.use(express.json());
+app.use(
+  cors({
+    origin: oauthConfig.allowedOrigin,
+    credentials: true,
+  }),
+);
+app.use(
+  session({
+    secret: oauthConfig.sessionSecret,
+    resave: false,
+    saveUninitialized: false,
+    cookie: {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: false,
+    },
+  }),
+);
+
+const pickerLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 30,
+});
+
+const mediaLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 60,
+});
+
+app.use('/auth', authRouter);
+app.use('/picker', pickerLimiter, pickerRouter);
+app.use('/media', mediaLimiter, mediaRouter);
+app.use('/slideshow', slideshowRouter);
+app.use('/llm', llmRouter);
+
+app.get('/healthz', (_req, res) => {
+  res.json({ ok: true });
+});
+
+export { app };

--- a/photos-carousel/apps/server/src/config/env.ts
+++ b/photos-carousel/apps/server/src/config/env.ts
@@ -1,0 +1,24 @@
+import { config } from 'dotenv';
+import { oauthConfigSchema } from '@photos-carousel/types';
+
+config();
+
+const parsed = oauthConfigSchema.safeParse({
+  clientId: process.env.GOOGLE_CLIENT_ID ?? '',
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
+  redirectUri: process.env.GOOGLE_REDIRECT_URI ?? 'http://localhost:3000/auth/callback',
+  allowedOrigin: process.env.GOOGLE_ALLOWED_ORIGIN ?? 'http://localhost:5173',
+  sessionSecret: process.env.SESSION_SECRET ?? 'change-me',
+});
+
+if (!parsed.success) {
+  console.warn('Invalid OAuth configuration, using placeholders.');
+}
+
+export const oauthConfig = {
+  clientId: parsed.success ? parsed.data.clientId : 'demo-client',
+  clientSecret: parsed.success ? parsed.data.clientSecret : 'demo-secret',
+  redirectUri: parsed.success ? parsed.data.redirectUri : 'http://localhost:3000/auth/callback',
+  allowedOrigin: parsed.success ? parsed.data.allowedOrigin : 'http://localhost:5173',
+  sessionSecret: parsed.success ? parsed.data.sessionSecret : 'change-me',
+};

--- a/photos-carousel/apps/server/src/index.ts
+++ b/photos-carousel/apps/server/src/index.ts
@@ -1,0 +1,8 @@
+import { app } from './app.js';
+import './services/mcp-server.js';
+
+const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+
+app.listen(port, () => {
+  console.log(`Server listening on http://localhost:${port}`);
+});

--- a/photos-carousel/apps/server/src/routes/auth.ts
+++ b/photos-carousel/apps/server/src/routes/auth.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+
+export const authRouter = Router();
+
+authRouter.post('/login', (_req, res) => {
+  res.json({ url: 'https://accounts.google.com/o/oauth2/v2/auth' });
+});
+
+authRouter.get('/callback', (_req, res) => {
+  res.send('OAuth callback placeholder');
+});

--- a/photos-carousel/apps/server/src/routes/llm.ts
+++ b/photos-carousel/apps/server/src/routes/llm.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import {
+  llmCommandRequestSchema,
+  llmCommandResponseSchema,
+  llmCommandSchema,
+  slideshowActionSchema,
+} from '@photos-carousel/types';
+import { getLastAction } from './slideshow.js';
+import { mcpClient } from '../services/mcp-client.js';
+
+export const llmRouter = Router();
+
+llmRouter.post('/command', async (req, res) => {
+  const parsed = llmCommandRequestSchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const command = parsed.data.command;
+
+  const action = slideshowActionSchema.safeParse(command.action);
+  if (action.success) {
+    await mcpClient.invoke('slideshow_control', { action: action.data });
+    const response = llmCommandResponseSchema.parse({
+      ok: true,
+      action: action.data,
+    });
+    return res.json(response);
+  }
+
+  const result = await mcpClient.invoke('list_media_items', { sessionId: 'mock-session' });
+  const response = llmCommandResponseSchema.parse({
+    ok: true,
+    action: command.action,
+    detail: JSON.stringify(result),
+  });
+  return res.json(response);
+});

--- a/photos-carousel/apps/server/src/routes/media.ts
+++ b/photos-carousel/apps/server/src/routes/media.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import {
+  listMediaItemsResponseSchema,
+  mediaContentQuerySchema,
+  mediaListQuerySchema,
+} from '@photos-carousel/types';
+import { generateMediaContentUrl, getSession, listSessionMedia } from '../services/picker.js';
+
+export const mediaRouter = Router();
+
+mediaRouter.get('/', (req, res) => {
+  const parsed = mediaListQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const session = getSession(parsed.data.sessionId);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+  const payload = listSessionMedia(parsed.data.sessionId);
+  return res.json(listMediaItemsResponseSchema.parse(payload));
+});
+
+mediaRouter.get('/:id/content', (req, res) => {
+  const parsed = mediaContentQuerySchema.safeParse({
+    w: req.query.w ? Number(req.query.w) : undefined,
+    h: req.query.h ? Number(req.query.h) : undefined,
+    crop: req.query.crop,
+  });
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const url = generateMediaContentUrl(req.params.id, parsed.data.w, parsed.data.h);
+  res.setHeader('Cache-Control', 'private, max-age=0, must-revalidate');
+  res.setHeader('Content-Type', 'image/jpeg');
+  res.send(`mock-binary-for-${url}`);
+});

--- a/photos-carousel/apps/server/src/routes/picker.ts
+++ b/photos-carousel/apps/server/src/routes/picker.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import {
+  pickerSessionCreateBodySchema,
+  pickerSessionResponseSchema,
+  pickerSessionStateSchema,
+} from '@photos-carousel/types';
+import { createPickerSession, getSession } from '../services/picker.js';
+
+export const pickerRouter = Router();
+
+pickerRouter.post('/session', (req, res) => {
+  const parsed = pickerSessionCreateBodySchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  const session = createPickerSession();
+  return res.json(pickerSessionResponseSchema.parse(session));
+});
+
+pickerRouter.get('/session/:id', (req, res) => {
+  const session = getSession(req.params.id);
+  if (!session) {
+    return res.status(404).json({ error: 'Session not found' });
+  }
+  return res.json(
+    pickerSessionStateSchema.parse({
+      mediaItemsSet: session.status === 'READY',
+      pollingConfig: { pollAfter: 4 },
+    }),
+  );
+});

--- a/photos-carousel/apps/server/src/routes/slideshow.ts
+++ b/photos-carousel/apps/server/src/routes/slideshow.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { slideshowActionSchema, slideshowControlSchema } from '@photos-carousel/types';
+
+let lastAction: string | null = null;
+
+export const slideshowRouter = Router();
+
+slideshowRouter.post('/control', (req, res) => {
+  const parsed = slideshowControlSchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+  lastAction = parsed.data.action;
+  return res.json({ ok: true, action: parsed.data.action });
+});
+
+export function getLastAction() {
+  return lastAction ? slideshowActionSchema.parse(lastAction) : null;
+}

--- a/photos-carousel/apps/server/src/services/mcp-client.ts
+++ b/photos-carousel/apps/server/src/services/mcp-client.ts
@@ -1,0 +1,13 @@
+import { mcpServer } from './mcp-server.js';
+
+class InProcessMCPClient {
+  async invoke(toolName: string, args: unknown) {
+    const handler = (mcpServer as any).getTool?.(toolName);
+    if (!handler) {
+      throw new Error(`Tool ${toolName} not found`);
+    }
+    return handler(args);
+  }
+}
+
+export const mcpClient = new InProcessMCPClient();

--- a/photos-carousel/apps/server/src/services/mcp-server.ts
+++ b/photos-carousel/apps/server/src/services/mcp-server.ts
@@ -1,0 +1,105 @@
+import { MCPServer as BaseMCPServer } from '@modelcontextprotocol/sdk';
+import { z } from 'zod';
+import {
+  applyFiltersSchema,
+  listMediaItemsResponseSchema,
+  mediaItemSchema,
+  pickerSessionResponseSchema,
+  pickerSessionStateSchema,
+  slideshowControlSchema,
+} from '@photos-carousel/types';
+import {
+  createPickerSession,
+  generateMediaContentUrl,
+  getSession,
+  listSessionMedia,
+} from './picker.js';
+
+class LocalMCPServer extends (BaseMCPServer as { new (config: { name: string }): any }) {
+  private tools = new Map<string, (args: unknown) => unknown>();
+
+  registerTool(spec: { name: string; description: string }, handler: (args: unknown) => unknown) {
+    this.tools.set(spec.name, handler);
+  }
+
+  getTool(name: string) {
+    return this.tools.get(name);
+  }
+}
+
+const server = new LocalMCPServer({ name: 'photos-carousel-mcp' });
+
+server.registerTool(
+  {
+    name: 'open_picker',
+    description: 'Crea una nueva sesión de Google Photos Picker',
+  },
+  async (args) => {
+    const filters = applyFiltersSchema.optional().parse(args?.filters);
+    const session = createPickerSession();
+    return pickerSessionResponseSchema.parse(session);
+  },
+);
+
+server.registerTool(
+  {
+    name: 'poll_session',
+    description: 'Obtiene el estado de una sesión de Picker',
+  },
+  async (args) => {
+    const schema = z.object({ sessionId: z.string() });
+    const input = schema.parse(args);
+    const session = getSession(input.sessionId);
+    if (!session) {
+      throw new Error('Session not found');
+    }
+    return pickerSessionStateSchema.parse({
+      mediaItemsSet: session.status === 'READY',
+      pollingConfig: { pollAfter: 4 },
+    });
+  },
+);
+
+server.registerTool(
+  {
+    name: 'list_media_items',
+    description: 'Lista los elementos seleccionados en una sesión de Picker',
+  },
+  async (args) => {
+    const schema = z.object({ sessionId: z.string(), pageToken: z.string().optional() });
+    const input = schema.parse(args);
+    const payload = listSessionMedia(input.sessionId);
+    return listMediaItemsResponseSchema.parse(payload);
+  },
+);
+
+server.registerTool(
+  {
+    name: 'get_image_blob',
+    description: 'Obtiene el blob de una imagen',
+  },
+  async (args) => {
+    const schema = z.object({
+      mediaItemId: z.string(),
+      w: z.number().optional(),
+      h: z.number().optional(),
+      crop: z.string().optional(),
+    });
+    const input = schema.parse(args);
+    const url = generateMediaContentUrl(input.mediaItemId, input.w, input.h);
+    return { mimeType: 'image/jpeg', url };
+  },
+);
+
+server.registerTool(
+  {
+    name: 'slideshow_control',
+    description: 'Controla el carrusel',
+  },
+  async (args) => {
+    const input = slideshowControlSchema.parse(args);
+    return { ok: true, action: input.action };
+  },
+);
+
+export const mcpServer = server;

--- a/photos-carousel/apps/server/src/services/picker.ts
+++ b/photos-carousel/apps/server/src/services/picker.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from 'crypto';
+import type { MediaItem } from '@photos-carousel/types';
+import { BASE_URL_TTL_MINUTES } from '@photos-carousel/types';
+
+type SessionStatus = 'PENDING' | 'READY';
+
+interface Session {
+  id: string;
+  pickerUri: string;
+  status: SessionStatus;
+  createdAt: number;
+  items: MediaItem[];
+}
+
+const sessions = new Map<string, Session>();
+
+function createMockItems(): MediaItem[] {
+  return Array.from({ length: 6 }).map((_, index) => ({
+    id: `mock-${index}`,
+    mimeType: 'image/jpeg',
+    baseUrl: `https://images.example.com/${index}`,
+    width: 1920,
+    height: 1080,
+    creationTime: new Date().toISOString(),
+  }));
+}
+
+export function createPickerSession() {
+  const id = randomUUID();
+  const pickerUri = `https://photos.google.com/picker?session=${id}`;
+  const session: Session = {
+    id,
+    pickerUri,
+    status: 'PENDING',
+    createdAt: Date.now(),
+    items: [],
+  };
+  sessions.set(id, session);
+  setTimeout(() => {
+    const readySession = sessions.get(id);
+    if (readySession) {
+      readySession.status = 'READY';
+      readySession.items = createMockItems();
+      sessions.set(id, readySession);
+    }
+  }, 3000);
+  return { sessionId: id, pickerUri };
+}
+
+export function getSession(sessionId: string) {
+  const session = sessions.get(sessionId);
+  if (!session) return null;
+  const expired = Date.now() - session.createdAt > BASE_URL_TTL_MINUTES * 60 * 1000;
+  if (expired) {
+    sessions.delete(sessionId);
+    return null;
+  }
+  return session;
+}
+
+export function listSessionMedia(sessionId: string) {
+  const session = sessions.get(sessionId);
+  if (!session) return { items: [], nextCursor: undefined };
+  return { items: session.items, nextCursor: undefined };
+}
+
+export function generateMediaContentUrl(mediaItemId: string, width?: number, height?: number) {
+  return `https://images.example.com/${mediaItemId}=w${width ?? 2048}-h${height ?? 0}`;
+}

--- a/photos-carousel/apps/server/src/types/modelcontextprotocol.d.ts
+++ b/photos-carousel/apps/server/src/types/modelcontextprotocol.d.ts
@@ -1,0 +1,15 @@
+declare module '@modelcontextprotocol/sdk' {
+  export interface MCPToolSpec {
+    name: string;
+    description: string;
+    schema?: unknown;
+  }
+
+  export type MCPHandler = (args: any) => Promise<unknown> | unknown;
+
+  export class MCPServer {
+    constructor(config: { name: string });
+    registerTool(spec: MCPToolSpec, handler: MCPHandler): void;
+    getTool(name: string): MCPHandler | undefined;
+  }
+}

--- a/photos-carousel/apps/server/tsconfig.json
+++ b/photos-carousel/apps/server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "references": [
+    { "path": "../../packages/types" }
+  ]
+}

--- a/photos-carousel/apps/web/index.html
+++ b/photos-carousel/apps/web/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/pwa-icon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <title>Photos Carousel</title>
+  </head>
+  <body class="bg-black text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/photos-carousel/apps/web/package.json
+++ b/photos-carousel/apps/web/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@photos-carousel/web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "test": "vitest run",
+    "test:ui": "playwright test",
+    "format": "prettier --write 'src/**/*.{ts,tsx,css}'",
+    "twa:init": "bubblewrap init --manifest=https://example.com/manifest.json"
+  },
+  "dependencies": {
+    "@photos-carousel/types": "workspace:^",
+    "@photos-carousel/ui": "workspace:^",
+    "@tanstack/react-query": "^5.20.1",
+    "axios": "^1.6.7",
+    "idb": "^7.1.1",
+    "masonry-layout": "^4.2.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1",
+    "use-gesture": "^10.2.27",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.41.2",
+    "@testing-library/jest-dom": "^6.4.1",
+    "@testing-library/react": "^14.2.1",
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "@types/wicg-file-system-access": "^2023.10.5",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8",
+    "vitest": "^1.3.1",
+    "workbox-build": "^7.0.0"
+  }
+}

--- a/photos-carousel/apps/web/playwright.config.ts
+++ b/photos-carousel/apps/web/playwright.config.ts
@@ -1,0 +1,11 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+  },
+};
+
+export default config;

--- a/photos-carousel/apps/web/postcss.config.cjs
+++ b/photos-carousel/apps/web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/photos-carousel/apps/web/public/manifest.webmanifest
+++ b/photos-carousel/apps/web/public/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Google Photos Carousel",
+  "short_name": "Carousel",
+  "display": "standalone",
+  "orientation": "landscape",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "start_url": ".",
+  "icons": [
+    {
+      "src": "/pwa-icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/photos-carousel/apps/web/public/pwa-icon.svg
+++ b/photos-carousel/apps/web/public/pwa-icon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#grad)" />
+  <path
+    d="M64 24c-8 12-24 24-24 36 0 12 12 20 24 28 12-8 24-16 24-28 0-12-16-24-24-36z"
+    fill="#fff"
+    opacity="0.8"
+  />
+  <circle cx="64" cy="64" r="14" fill="#0f172a" opacity="0.85" />
+</svg>

--- a/photos-carousel/apps/web/src/__tests__/lru.test.ts
+++ b/photos-carousel/apps/web/src/__tests__/lru.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LRUCache } from '../lib/lru.js';
+
+describe('LRUCache', () => {
+  it('evicts oldest entries when over capacity', () => {
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    const cache = new LRUCache<string>(10);
+    cache.set('a', 'a', 6);
+    vi.setSystemTime(new Date('2024-01-01T00:00:01Z'));
+    cache.set('b', 'b', 6);
+    expect(cache.keys()).toContain('b');
+    expect(cache.keys()).not.toContain('a');
+  });
+});

--- a/photos-carousel/apps/web/src/__tests__/slideshow-store.test.ts
+++ b/photos-carousel/apps/web/src/__tests__/slideshow-store.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { useSlideshowStore } from '../store/slideshow.js';
+
+describe('slideshow store', () => {
+  it('handles actions correctly', () => {
+    const { applyAction, playback } = useSlideshowStore.getState();
+    expect(playback).toBe('PAUSED');
+    applyAction('PLAY');
+    expect(useSlideshowStore.getState().playback).toBe('PLAYING');
+    applyAction('PAUSE');
+    expect(useSlideshowStore.getState().playback).toBe('PAUSED');
+  });
+});

--- a/photos-carousel/apps/web/src/components/command-panel.tsx
+++ b/photos-carousel/apps/web/src/components/command-panel.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import type { LLMCommand } from '@photos-carousel/types';
+import { Button } from '@photos-carousel/ui';
+import { sendLLMCommand } from '../lib/api.js';
+import { useSlideshowStore } from '../store/slideshow.js';
+
+export function CommandPanel() {
+  const [input, setInput] = useState('');
+  const [result, setResult] = useState('');
+  const applyAction = useSlideshowStore((state) => state.applyAction);
+
+  const handleSubmit = async () => {
+    try {
+      const mockCommand: LLMCommand = { action: 'LIST' };
+      const response = await sendLLMCommand(mockCommand);
+      if (response.action && ['PLAY', 'PAUSE', 'NEXT', 'PREV', 'SHUFFLE'].includes(response.action)) {
+        applyAction(response.action as LLMCommand['action']);
+      }
+      setResult(JSON.stringify(response));
+      setInput('');
+    } catch (error) {
+      setResult(error instanceof Error ? error.message : 'Error');
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl bg-white/5 p-4 text-sm text-white">
+      <h2 className="text-lg font-semibold">Comandos por texto</h2>
+      <textarea
+        className="min-h-[96px] rounded-lg bg-black/40 p-3"
+        placeholder="Ej. \"pon pausa\" o \"siguiente foto\""
+        value={input}
+        onChange={(event) => setInput(event.target.value)}
+      />
+      <Button onClick={handleSubmit}>Enviar comando</Button>
+      {result && <pre className="whitespace-pre-wrap text-xs text-white/70">{result}</pre>}
+    </div>
+  );
+}

--- a/photos-carousel/apps/web/src/components/filters-panel.tsx
+++ b/photos-carousel/apps/web/src/components/filters-panel.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import type { LLMCommand } from '@photos-carousel/types';
+import { Button } from '@photos-carousel/ui';
+
+interface FiltersPanelProps {
+  onApply: (filters: LLMCommand['filters']) => void;
+}
+
+export function FiltersPanel({ onApply }: FiltersPanelProps) {
+  const [orientation, setOrientation] = useState<LLMCommand['filters']['orientation']>();
+  const [mime, setMime] = useState('image/jpeg');
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl bg-white/5 p-4 text-sm text-white">
+      <h2 className="text-lg font-semibold">Filtros locales</h2>
+      <div className="flex gap-2">
+        <Button
+          variant={orientation === 'portrait' ? 'primary' : 'ghost'}
+          onClick={() => setOrientation(orientation === 'portrait' ? undefined : 'portrait')}
+        >
+          Vertical
+        </Button>
+        <Button
+          variant={orientation === 'landscape' ? 'primary' : 'ghost'}
+          onClick={() => setOrientation(orientation === 'landscape' ? undefined : 'landscape')}
+        >
+          Horizontal
+        </Button>
+      </div>
+      <label className="flex flex-col gap-2 text-white/80">
+        Tipo MIME
+        <select
+          value={mime}
+          onChange={(event) => setMime(event.target.value)}
+          className="rounded-lg bg-black/40 p-2"
+        >
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/png">PNG</option>
+          <option value="image/webp">WEBP</option>
+        </select>
+      </label>
+      <Button
+        onClick={() => onApply({ orientation, mime: [mime] })}
+        className="mt-2"
+      >
+        Aplicar filtros
+      </Button>
+    </div>
+  );
+}

--- a/photos-carousel/apps/web/src/components/privacy-banner.tsx
+++ b/photos-carousel/apps/web/src/components/privacy-banner.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { Button } from '@photos-carousel/ui';
+
+export function PrivacyBanner() {
+  const [visible, setVisible] = useState(true);
+  if (!visible) return null;
+  return (
+    <div className="fixed bottom-4 left-1/2 z-50 w-[90%] max-w-3xl -translate-x-1/2 rounded-2xl bg-white/10 p-4 text-sm text-white">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <p>
+          Las fotos se procesan solo en tu dispositivo. No almacenamos tus imágenes y el acceso a
+          Google Photos se realiza mediante OAuth seguro.
+        </p>
+        <Button variant="primary" onClick={() => setVisible(false)}>
+          Entendido
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/photos-carousel/apps/web/src/components/slideshow-controls.tsx
+++ b/photos-carousel/apps/web/src/components/slideshow-controls.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@photos-carousel/ui';
+import { useSlideshowStore } from '../store/slideshow.js';
+
+export function SlideshowControls() {
+  const playback = useSlideshowStore((state) => state.playback);
+  const togglePlay = useSlideshowStore((state) => state.togglePlay);
+  const next = useSlideshowStore((state) => state.next);
+  const prev = useSlideshowStore((state) => state.prev);
+  const shuffle = useSlideshowStore((state) => state.shuffle);
+  const setShuffle = useSlideshowStore((state) => state.setShuffle);
+
+  return (
+    <div className="flex items-center gap-4">
+      <Button variant="ghost" onClick={prev} aria-label="Anterior">
+        ⬅️
+      </Button>
+      <Button onClick={togglePlay} aria-label="Play/Pausa">
+        {playback === 'PLAYING' ? '⏸️' : '▶️'}
+      </Button>
+      <Button variant="ghost" onClick={next} aria-label="Siguiente">
+        ➡️
+      </Button>
+      <Button variant={shuffle ? 'primary' : 'ghost'} onClick={() => setShuffle(!shuffle)}>
+        🔀
+      </Button>
+    </div>
+  );
+}

--- a/photos-carousel/apps/web/src/components/slideshow-viewer.tsx
+++ b/photos-carousel/apps/web/src/components/slideshow-viewer.tsx
@@ -1,0 +1,64 @@
+import { useMemo, useState } from 'react';
+import type { MediaItem } from '@photos-carousel/types';
+import { useSlideshowStore } from '../store/slideshow.js';
+import { useMediaContent } from '../hooks/useMediaContent.js';
+import { useAutoplay } from '../hooks/useAutoplay.js';
+
+interface SlideshowViewerProps {
+  items: MediaItem[];
+}
+
+export function SlideshowViewer({ items }: SlideshowViewerProps) {
+  const currentIndex = useSlideshowStore((state) => state.currentIndex);
+  const setHudVisible = useSlideshowStore((state) => state.setHudVisible);
+  const next = useSlideshowStore((state) => state.next);
+  const prev = useSlideshowStore((state) => state.prev);
+  const togglePlay = useSlideshowStore((state) => state.togglePlay);
+  const [zoomed, setZoomed] = useState(false);
+  const [lastTap, setLastTap] = useState(0);
+  const currentItem = useMemo(() => items[currentIndex], [items, currentIndex]);
+  const { url, loading, error } = useMediaContent(currentItem);
+
+  useAutoplay();
+
+  const handleTap = () => {
+    const now = Date.now();
+    if (now - lastTap < 300) {
+      setZoomed((z) => !z);
+    } else {
+      setHudVisible(true);
+    }
+    setLastTap(now);
+  };
+
+  return (
+    <div
+      className="relative flex h-full w-full items-center justify-center overflow-hidden bg-black"
+      onClick={handleTap}
+      onKeyDown={(event) => {
+        if (event.key === 'ArrowRight') {
+          next();
+        }
+        if (event.key === 'ArrowLeft') {
+          prev();
+        }
+        if (event.key === ' ') {
+          event.preventDefault();
+          togglePlay();
+        }
+      }}
+      tabIndex={0}
+    >
+      {loading && <div className="text-white/70">Cargando...</div>}
+      {error && <div className="text-red-400">{error}</div>}
+      {url && (
+        <img
+          src={url}
+          alt={currentItem?.id ?? 'Imagen'}
+          className="max-h-full max-w-full rounded-xl shadow-2xl transition-transform duration-200"
+          style={{ transform: zoomed ? 'scale(1.4)' : 'scale(1)' }}
+        />
+      )}
+    </div>
+  );
+}

--- a/photos-carousel/apps/web/src/hooks/useAutoplay.ts
+++ b/photos-carousel/apps/web/src/hooks/useAutoplay.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+import { useSlideshowStore } from '../store/slideshow.js';
+
+export function useAutoplay() {
+  const playback = useSlideshowStore((state) => state.playback);
+  const interval = useSlideshowStore((state) => state.autoplayInterval);
+  const next = useSlideshowStore((state) => state.next);
+  const timer = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (playback !== 'PLAYING') {
+      if (timer.current) {
+        clearInterval(timer.current);
+      }
+      return;
+    }
+    timer.current = setInterval(() => {
+      next();
+    }, interval);
+
+    return () => {
+      if (timer.current) {
+        clearInterval(timer.current);
+      }
+    };
+  }, [interval, next, playback]);
+}

--- a/photos-carousel/apps/web/src/hooks/useFullscreen.ts
+++ b/photos-carousel/apps/web/src/hooks/useFullscreen.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export function useFullscreen(target?: () => HTMLElement | null) {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const request = useCallback(async () => {
+    const element = target?.() ?? document.documentElement;
+    if (element.requestFullscreen) {
+      await element.requestFullscreen();
+    }
+  }, [target]);
+
+  const exit = useCallback(async () => {
+    if (document.fullscreenElement) {
+      await document.exitFullscreen();
+    }
+  }, []);
+
+  useEffect(() => {
+    const handle = () => {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+    };
+    document.addEventListener('fullscreenchange', handle);
+    return () => document.removeEventListener('fullscreenchange', handle);
+  }, []);
+
+  return { isFullscreen, request, exit };
+}

--- a/photos-carousel/apps/web/src/hooks/useMediaContent.ts
+++ b/photos-carousel/apps/web/src/hooks/useMediaContent.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { getBlob, putBlob } from '../lib/cache.js';
+import type { MediaItem } from '@photos-carousel/types';
+
+async function fetchMedia(item: MediaItem, width = 2048) {
+  const params = new URLSearchParams();
+  params.set('w', String(width));
+  const response = await fetch(`/api/media/${item.id}/content?${params.toString()}`, {
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error('Unable to download media item');
+  }
+  return await response.blob();
+}
+
+export function useMediaContent(item: MediaItem | undefined) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let aborted = false;
+    if (!item) {
+      setUrl(null);
+      return () => undefined;
+    }
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const cached = await getBlob(item.id);
+        const blob = cached ?? (await fetchMedia(item));
+        if (!cached) {
+          await putBlob(item.id, blob);
+        }
+        if (aborted) return;
+        const objectUrl = URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      } catch (err) {
+        if (!aborted) {
+          setError(err instanceof Error ? err.message : 'Error desconocido');
+        }
+      } finally {
+        if (!aborted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+
+    return () => {
+      aborted = true;
+      if (url) {
+        URL.revokeObjectURL(url);
+      }
+    };
+  }, [item?.id]);
+
+  return { url, loading, error };
+}

--- a/photos-carousel/apps/web/src/lib/api.ts
+++ b/photos-carousel/apps/web/src/lib/api.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+import type {
+  LLMCommand,
+  ListMediaItemsResponse,
+  PickerSessionResponse,
+  PickerSessionState,
+} from '@photos-carousel/types';
+
+const client = axios.create({
+  baseURL: '/api',
+  withCredentials: true,
+});
+
+export async function createPickerSession(filters?: LLMCommand['filters']): Promise<PickerSessionResponse> {
+  const response = await client.post<PickerSessionResponse>('/picker/session', { filters });
+  return response.data;
+}
+
+export async function getPickerSessionState(sessionId: string): Promise<PickerSessionState> {
+  const response = await client.get<PickerSessionState>(`/picker/session/${sessionId}`);
+  return response.data;
+}
+
+export async function listMediaItems(
+  sessionId: string,
+  cursor?: string,
+): Promise<ListMediaItemsResponse> {
+  const response = await client.get<ListMediaItemsResponse>('/media', {
+    params: { sessionId, cursor },
+  });
+  return response.data;
+}
+
+export async function controlSlideshow(action: string) {
+  await client.post('/slideshow/control', { action });
+}
+
+export async function sendLLMCommand(command: LLMCommand) {
+  const response = await client.post('/llm/command', { command });
+  return response.data;
+}

--- a/photos-carousel/apps/web/src/lib/cache.ts
+++ b/photos-carousel/apps/web/src/lib/cache.ts
@@ -1,0 +1,85 @@
+import { openDB } from 'idb';
+import {
+  BASE_URL_REFRESH_THRESHOLD_MINUTES,
+  BASE_URL_TTL_MINUTES,
+} from '@photos-carousel/types';
+
+const DB_NAME = 'photos-carousel-cache';
+const STORE_NAME = 'media-blobs';
+const MAX_CACHE_BYTES = 200 * 1024 * 1024; // 200 MB
+
+interface CachedEntry {
+  id: string;
+  blob: Blob;
+  size: number;
+  createdAt: number;
+}
+
+async function getDb() {
+  return openDB(DB_NAME, 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        store.createIndex('createdAt', 'createdAt');
+      }
+    },
+  });
+}
+
+export async function putBlob(id: string, blob: Blob) {
+  const db = await getDb();
+  const entry: CachedEntry = {
+    id,
+    blob,
+    size: blob.size,
+    createdAt: Date.now(),
+  };
+  await db.put(STORE_NAME, entry);
+  await enforceQuota(db);
+}
+
+export async function getBlob(id: string): Promise<Blob | null> {
+  const db = await getDb();
+  const entry = await db.get<CachedEntry>(STORE_NAME, id);
+  if (!entry) return null;
+  const ageMinutes = (Date.now() - entry.createdAt) / (1000 * 60);
+  if (ageMinutes > BASE_URL_TTL_MINUTES) {
+    await db.delete(STORE_NAME, id);
+    return null;
+  }
+  if (ageMinutes > BASE_URL_REFRESH_THRESHOLD_MINUTES) {
+    return null;
+  }
+  return entry.blob;
+}
+
+async function enforceQuota(db: Awaited<ReturnType<typeof getDb>>) {
+  let total = 0;
+  const entries = await db.getAll(STORE_NAME);
+  entries.sort((a, b) => a.createdAt - b.createdAt);
+  for (const entry of entries) {
+    total += entry.size;
+  }
+  while (total > MAX_CACHE_BYTES && entries.length > 0) {
+    const oldest = entries.shift();
+    if (!oldest) break;
+    total -= oldest.size;
+    await db.delete(STORE_NAME, oldest.id);
+  }
+}
+
+export async function clearExpired() {
+  const db = await getDb();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.store;
+  const now = Date.now();
+  let cursor = await store.openCursor();
+  while (cursor) {
+    const ageMinutes = (now - cursor.value.createdAt) / (1000 * 60);
+    if (ageMinutes > BASE_URL_TTL_MINUTES) {
+      await cursor.delete();
+    }
+    cursor = await cursor.continue();
+  }
+  await tx.done;
+}

--- a/photos-carousel/apps/web/src/lib/lru.ts
+++ b/photos-carousel/apps/web/src/lib/lru.ts
@@ -1,0 +1,53 @@
+export interface LRUEntry<T> {
+  key: string;
+  value: T;
+  size: number;
+  timestamp: number;
+}
+
+export class LRUCache<T> {
+  private readonly limit: number;
+  private entries = new Map<string, LRUEntry<T>>();
+  private totalSize = 0;
+
+  constructor(limit: number) {
+    this.limit = limit;
+  }
+
+  set(key: string, value: T, size: number) {
+    const entry: LRUEntry<T> = { key, value, size, timestamp: Date.now() };
+    const existing = this.entries.get(key);
+    if (existing) {
+      this.totalSize -= existing.size;
+    }
+    this.entries.set(key, entry);
+    this.totalSize += size;
+    this.evict();
+  }
+
+  get(key: string): T | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    entry.timestamp = Date.now();
+    this.entries.set(key, entry);
+    return entry.value;
+  }
+
+  private evict() {
+    if (this.totalSize <= this.limit) return;
+    const sorted = Array.from(this.entries.values()).sort((a, b) => a.timestamp - b.timestamp);
+    for (const entry of sorted) {
+      if (this.totalSize <= this.limit) break;
+      this.entries.delete(entry.key);
+      this.totalSize -= entry.size;
+    }
+  }
+
+  size(): number {
+    return this.totalSize;
+  }
+
+  keys(): string[] {
+    return Array.from(this.entries.keys());
+  }
+}

--- a/photos-carousel/apps/web/src/main.tsx
+++ b/photos-carousel/apps/web/src/main.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { router } from './router.js';
+import './styles.css';
+import { registerServiceWorker } from './register-sw.js';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  </React.StrictMode>,
+);
+
+registerServiceWorker();

--- a/photos-carousel/apps/web/src/register-sw.ts
+++ b/photos-carousel/apps/web/src/register-sw.ts
@@ -1,0 +1,9 @@
+export async function registerServiceWorker() {
+  if ('serviceWorker' in navigator) {
+    try {
+      await navigator.serviceWorker.register('/sw.js');
+    } catch (error) {
+      console.error('Service worker registration failed', error);
+    }
+  }
+}

--- a/photos-carousel/apps/web/src/router.tsx
+++ b/photos-carousel/apps/web/src/router.tsx
@@ -1,0 +1,9 @@
+import { createBrowserRouter } from 'react-router-dom';
+import { RootLayout } from './screens/root-layout.js';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <RootLayout />,
+  },
+]);

--- a/photos-carousel/apps/web/src/screens/root-layout.tsx
+++ b/photos-carousel/apps/web/src/screens/root-layout.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { MediaItem } from '@photos-carousel/types';
+import { Button, HUD } from '@photos-carousel/ui';
+import { SlideshowViewer } from '../components/slideshow-viewer.js';
+import { SlideshowControls } from '../components/slideshow-controls.js';
+import { FiltersPanel } from '../components/filters-panel.js';
+import { CommandPanel } from '../components/command-panel.js';
+import { createPickerSession, getPickerSessionState, listMediaItems } from '../lib/api.js';
+import { useSlideshowStore } from '../store/slideshow.js';
+import { PrivacyBanner } from '../components/privacy-banner.js';
+
+interface SessionState {
+  sessionId: string;
+  pickerUri: string;
+}
+
+export function RootLayout() {
+  const [session, setSession] = useState<SessionState | null>(null);
+  const [loadingSession, setLoadingSession] = useState(false);
+  const [statusMessage, setStatusMessage] = useState('');
+  const [mediaItems, setMediaItems] = useState<MediaItem[]>([]);
+  const [polling, setPolling] = useState(false);
+  const setItems = useSlideshowStore((state) => state.setItems);
+  const hudVisible = useSlideshowStore((state) => state.hudVisible);
+  const toggleHud = useSlideshowStore((state) => state.toggleHud);
+  const applyAction = useSlideshowStore((state) => state.applyAction);
+
+  useEffect(() => {
+    setItems(mediaItems);
+  }, [mediaItems, setItems]);
+
+  useEffect(() => {
+    if (!session || !polling) return;
+    let active = true;
+    const interval = setInterval(async () => {
+      if (!active) return;
+      const state = await getPickerSessionState(session.sessionId);
+      if (state.mediaItemsSet) {
+        clearInterval(interval);
+        setPolling(false);
+        const result = await listMediaItems(session.sessionId);
+        setMediaItems(result.items);
+        setStatusMessage('Selección lista');
+      } else {
+        setStatusMessage('Esperando selección...');
+      }
+    }, 4000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [session, polling]);
+
+  const currentItem = useMemo(() => mediaItems[useSlideshowStore.getState().currentIndex], [mediaItems]);
+
+  const handleCreateSession = async () => {
+    setLoadingSession(true);
+    try {
+      const response = await createPickerSession();
+      setSession(response);
+      setPolling(true);
+      setStatusMessage('Abre el selector en Google Photos...');
+      window.open(response.pickerUri, '_blank');
+    } catch (error) {
+      setStatusMessage(error instanceof Error ? error.message : 'Error al crear la sesión');
+    } finally {
+      setLoadingSession(false);
+    }
+  };
+
+  const handleApplyFilters = async (filters: Parameters<typeof createPickerSession>[0]) => {
+    if (!session) return;
+    const filtered = mediaItems.filter((item) => {
+      if (filters?.orientation && item.width && item.height) {
+        const orientation = item.width > item.height ? 'landscape' : 'portrait';
+        if (orientation !== filters.orientation) {
+          return false;
+        }
+      }
+      if (filters?.mime && !filters.mime.includes(item.mimeType)) {
+        return false;
+      }
+      return true;
+    });
+    setMediaItems(filtered);
+  };
+
+  return (
+    <div className="flex min-h-screen w-full flex-col gap-6 bg-gradient-to-br from-black via-slate-900 to-black p-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-3xl font-semibold">Carrusel Google Photos</h1>
+        <div className="flex items-center gap-4">
+          <Button onClick={handleCreateSession} disabled={loadingSession}>
+            Elegir en Google Photos
+          </Button>
+          <Button variant="ghost" onClick={() => applyAction('PLAY')}>
+            ▶️
+          </Button>
+          <Button variant="ghost" onClick={() => applyAction('PAUSE')}>
+            ⏸️
+          </Button>
+        </div>
+      </header>
+      <main className="grid h-full flex-1 gap-6 lg:grid-cols-[2fr_1fr]">
+        <section className="relative flex h-full flex-col overflow-hidden rounded-3xl border border-white/10">
+          <SlideshowViewer items={mediaItems} />
+          <HUD visible={hudVisible}>
+            <SlideshowControls />
+            {currentItem && (
+              <span className="text-sm text-white/70">
+                {useSlideshowStore.getState().currentIndex + 1} / {mediaItems.length}
+              </span>
+            )}
+            <Button variant="ghost" onClick={toggleHud}>
+              HUD
+            </Button>
+          </HUD>
+          {statusMessage && (
+            <div className="absolute left-4 top-4 rounded-full bg-black/70 px-4 py-2 text-sm text-white/80">
+              {statusMessage}
+            </div>
+          )}
+        </section>
+        <aside className="flex flex-col gap-4">
+          <FiltersPanel onApply={handleApplyFilters} />
+          <CommandPanel />
+          <div className="rounded-2xl bg-white/5 p-4 text-sm text-white/80">
+            <h2 className="text-lg font-semibold">Ayuda</h2>
+            <p>
+              Usa gestos de swipe para navegar, doble toque para zoom y mantén pulsado para mostrar
+              controles.
+            </p>
+          </div>
+        </aside>
+      </main>
+      <PrivacyBanner />
+    </div>
+  );
+}

--- a/photos-carousel/apps/web/src/service-worker/sw.ts
+++ b/photos-carousel/apps/web/src/service-worker/sw.ts
@@ -1,0 +1,25 @@
+/// <reference lib="webworker" />
+import { clientsClaim } from 'workbox-core';
+import { ExpirationPlugin } from 'workbox-expiration';
+import { precacheAndRoute } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+import { CacheFirst } from 'workbox-strategies';
+
+declare let self: ServiceWorkerGlobalScope;
+
+clientsClaim();
+precacheAndRoute(self.__WB_MANIFEST || []);
+
+registerRoute(
+  ({ url }) => url.pathname.startsWith('/api/media/'),
+  new CacheFirst({
+    cacheName: 'media-blobs',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 200,
+        maxAgeSeconds: 55 * 60,
+      }),
+    ],
+  }),
+  'GET',
+);

--- a/photos-carousel/apps/web/src/store/slideshow.ts
+++ b/photos-carousel/apps/web/src/store/slideshow.ts
@@ -1,0 +1,85 @@
+import { create } from 'zustand';
+import type { MediaItem, SlideshowAction } from '@photos-carousel/types';
+
+type PlaybackMode = 'PLAYING' | 'PAUSED';
+
+interface SlideshowState {
+  items: MediaItem[];
+  currentIndex: number;
+  playback: PlaybackMode;
+  shuffle: boolean;
+  hudVisible: boolean;
+  autoplayInterval: number;
+  setItems: (items: MediaItem[]) => void;
+  setCurrentIndex: (index: number) => void;
+  next: () => void;
+  prev: () => void;
+  togglePlay: () => void;
+  setShuffle: (value: boolean) => void;
+  toggleHud: () => void;
+  setHudVisible: (visible: boolean) => void;
+  setAutoplayInterval: (ms: number) => void;
+  applyAction: (action: SlideshowAction) => void;
+}
+
+const clampIndex = (index: number, length: number) => {
+  if (length === 0) {
+    return 0;
+  }
+  return (index + length) % length;
+};
+
+export const useSlideshowStore = create<SlideshowState>((set, get) => ({
+  items: [],
+  currentIndex: 0,
+  playback: 'PAUSED',
+  shuffle: false,
+  hudVisible: true,
+  autoplayInterval: 12000,
+  setItems: (items) => set({ items, currentIndex: 0 }),
+  setCurrentIndex: (index) => {
+    const { items } = get();
+    set({ currentIndex: clampIndex(index, items.length) });
+  },
+  next: () => {
+    const { items, shuffle, currentIndex } = get();
+    if (items.length === 0) return;
+    const nextIndex = shuffle ? Math.floor(Math.random() * items.length) : currentIndex + 1;
+    set({ currentIndex: clampIndex(nextIndex, items.length) });
+  },
+  prev: () => {
+    const { items, currentIndex } = get();
+    if (items.length === 0) return;
+    set({ currentIndex: clampIndex(currentIndex - 1, items.length) });
+  },
+  togglePlay: () => {
+    set((state) => ({ playback: state.playback === 'PLAYING' ? 'PAUSED' : 'PLAYING' }));
+  },
+  setShuffle: (value) => set({ shuffle: value }),
+  toggleHud: () => set((state) => ({ hudVisible: !state.hudVisible })),
+  setHudVisible: (visible) => set({ hudVisible: visible }),
+  setAutoplayInterval: (ms) => set({ autoplayInterval: ms }),
+  applyAction: (action) => {
+    const { togglePlay, next, prev, setShuffle } = get();
+    switch (action) {
+      case 'PLAY':
+        set({ playback: 'PLAYING' });
+        break;
+      case 'PAUSE':
+        set({ playback: 'PAUSED' });
+        break;
+      case 'NEXT':
+        next();
+        break;
+      case 'PREV':
+        prev();
+        break;
+      case 'SHUFFLE':
+        setShuffle(true);
+        break;
+      default:
+        togglePlay();
+        break;
+    }
+  },
+}));

--- a/photos-carousel/apps/web/src/styles.css
+++ b/photos-carousel/apps/web/src/styles.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body, html, #root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  font-family: 'Segoe UI', system-ui, sans-serif;
+  background-color: #000;
+}
+
+button {
+  touch-action: manipulation;
+}

--- a/photos-carousel/apps/web/tailwind.config.cjs
+++ b/photos-carousel/apps/web/tailwind.config.cjs
@@ -1,0 +1,16 @@
+const config = {
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        display: ['"Segoe UI"', 'system-ui', 'sans-serif'],
+      },
+      colors: {
+        hud: 'rgba(0,0,0,0.65)'
+      }
+    },
+  },
+  plugins: [],
+};
+
+module.exports = config;

--- a/photos-carousel/apps/web/tests/picker.spec.ts
+++ b/photos-carousel/apps/web/tests/picker.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('shows picker button and status flow', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('button', { name: 'Elegir en Google Photos' })).toBeVisible();
+});

--- a/photos-carousel/apps/web/tsconfig.json
+++ b/photos-carousel/apps/web/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "composite": true,
+    "types": ["vite/client", "@types/wicg-file-system-access"]
+  },
+  "include": ["src", "vite.config.ts", "playwright.config.ts"],
+  "references": [
+    { "path": "../../packages/types" },
+    { "path": "../../packages/ui" }
+  ]
+}

--- a/photos-carousel/apps/web/vite.config.ts
+++ b/photos-carousel/apps/web/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+  build: {
+    outDir: 'dist',
+  }
+});

--- a/photos-carousel/package.json
+++ b/photos-carousel/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "photos-carousel-monorepo",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "type": "module",
+  "scripts": {
+    "build": "pnpm -r build",
+    "lint": "pnpm -r lint",
+    "test": "pnpm -r test",
+    "format": "pnpm -r format",
+    "dev:web": "pnpm --filter @photos-carousel/web dev",
+    "dev:server": "pnpm --filter @photos-carousel/server dev",
+    "dev": "pnpm run dev:server & pnpm run dev:web"
+  },
+  "devDependencies": {
+    "@types/eslint": "^8.56.6",
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.3.3"
+  }
+}

--- a/photos-carousel/packages/types/package.json
+++ b/photos-carousel/packages/types/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@photos-carousel/types",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "test": "vitest run",
+    "format": "prettier --write 'src/**/*.{ts,tsx}'"
+  },
+  "dependencies": {
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  }
+}

--- a/photos-carousel/packages/types/src/__tests__/constants.test.ts
+++ b/photos-carousel/packages/types/src/__tests__/constants.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BASE_URL_REFRESH_THRESHOLD_MINUTES,
+  BASE_URL_TTL_MINUTES,
+  GOOGLE_PHOTOS_PICKER_SCOPE,
+  llmCommandSchema,
+} from '../index.js';
+
+describe('constants', () => {
+  it('defines the Google Photos Picker scope', () => {
+    expect(GOOGLE_PHOTOS_PICKER_SCOPE).toBe(
+      'https://www.googleapis.com/auth/photospicker.mediaitems.readonly',
+    );
+  });
+
+  it('ensures the refresh threshold is less than the TTL', () => {
+    expect(BASE_URL_REFRESH_THRESHOLD_MINUTES).toBeLessThan(BASE_URL_TTL_MINUTES);
+  });
+
+  it('validates a minimal LLM command payload', () => {
+    const result = llmCommandSchema.safeParse({ action: 'PLAY' });
+    expect(result.success).toBe(true);
+  });
+});

--- a/photos-carousel/packages/types/src/index.ts
+++ b/photos-carousel/packages/types/src/index.ts
@@ -1,0 +1,124 @@
+import { z } from 'zod';
+
+export const GOOGLE_PHOTOS_PICKER_SCOPE =
+  'https://www.googleapis.com/auth/photospicker.mediaitems.readonly';
+
+export const BASE_URL_TTL_MINUTES = 60;
+export const BASE_URL_REFRESH_THRESHOLD_MINUTES = 55;
+
+export const slideshowActionSchema = z.enum(['PLAY', 'PAUSE', 'NEXT', 'PREV', 'SHUFFLE']);
+export type SlideshowAction = z.infer<typeof slideshowActionSchema>;
+
+export const llmCommandSchema = z.object({
+  action: z.union([
+    slideshowActionSchema,
+    z.literal('OPEN_PICKER'),
+    z.literal('APPLY_FILTERS'),
+    z.literal('LIST'),
+  ]),
+  filters: z
+    .object({
+      orientation: z.enum(['portrait', 'landscape']).optional(),
+      mime: z.array(z.string()).optional(),
+      dateRange: z
+        .object({
+          from: z.string().datetime({ offset: true }).optional(),
+          to: z.string().datetime({ offset: true }).optional(),
+        })
+        .partial()
+        .optional(),
+    })
+    .optional(),
+});
+export type LLMCommand = z.infer<typeof llmCommandSchema>;
+
+export const pickerFilterSchema = z
+  .object({
+    orientation: z.enum(['portrait', 'landscape']).optional(),
+    mime: z.array(z.string()).optional(),
+    dateRange: z
+      .object({
+        from: z.string().datetime({ offset: true }).optional(),
+        to: z.string().datetime({ offset: true }).optional(),
+      })
+      .partial()
+      .optional(),
+  })
+  .optional();
+
+export const pickerSessionResponseSchema = z.object({
+  sessionId: z.string(),
+  pickerUri: z.string().url(),
+});
+
+export const pickerSessionStateSchema = z.object({
+  mediaItemsSet: z.boolean(),
+  pollingConfig: z
+    .object({
+      pollAfter: z.number().optional(),
+    })
+    .partial()
+    .optional(),
+});
+
+export const mediaItemSchema = z.object({
+  id: z.string(),
+  mimeType: z.string(),
+  baseUrl: z.string().url().optional(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  creationTime: z.string().datetime().optional(),
+});
+
+export const listMediaItemsResponseSchema = z.object({
+  items: z.array(mediaItemSchema),
+  nextCursor: z.string().optional(),
+});
+
+export const slideshowControlSchema = z.object({
+  action: slideshowActionSchema,
+});
+
+export const applyFiltersSchema = z.object({
+  orientation: z.enum(['portrait', 'landscape']).optional(),
+  mime: z.array(z.string()).optional(),
+});
+
+export const llmCommandResponseSchema = z.object({
+  ok: z.boolean(),
+  action: z.string(),
+  detail: z.string().optional(),
+});
+
+export const pickerSessionCreateBodySchema = z.object({
+  filters: pickerFilterSchema,
+});
+
+export const mediaListQuerySchema = z.object({
+  sessionId: z.string(),
+  cursor: z.string().optional(),
+});
+
+export const mediaContentQuerySchema = z.object({
+  w: z.number().int().positive().optional(),
+  h: z.number().int().positive().optional(),
+  crop: z.enum(['c']).optional(),
+});
+
+export const llmCommandRequestSchema = z.object({
+  command: llmCommandSchema,
+});
+
+export const oauthConfigSchema = z.object({
+  clientId: z.string(),
+  clientSecret: z.string(),
+  redirectUri: z.string().url(),
+  allowedOrigin: z.string().url(),
+  sessionSecret: z.string(),
+});
+
+export type PickerSessionResponse = z.infer<typeof pickerSessionResponseSchema>;
+export type PickerSessionState = z.infer<typeof pickerSessionStateSchema>;
+export type MediaItem = z.infer<typeof mediaItemSchema>;
+export type ListMediaItemsResponse = z.infer<typeof listMediaItemsResponseSchema>;
+export type LLMCommandResponse = z.infer<typeof llmCommandResponseSchema>;

--- a/photos-carousel/packages/types/tsconfig.json
+++ b/photos-carousel/packages/types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "references": []
+}

--- a/photos-carousel/packages/ui/package.json
+++ b/photos-carousel/packages/ui/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@photos-carousel/ui",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -b",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "test": "vitest run",
+    "format": "prettier --write 'src/**/*.{ts,tsx}'"
+  },
+  "dependencies": {
+    "clsx": "^2.1.0",
+    "tailwind-merge": "^2.2.1",
+    "@photos-carousel/types": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "@types/node": "^20.11.30",
+    "typescript": "^5.3.3",
+    "vitest": "^1.3.1"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/photos-carousel/packages/ui/src/__tests__/utils.test.ts
+++ b/photos-carousel/packages/ui/src/__tests__/utils.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from '../../src/utils.js';
+
+describe('cn utility', () => {
+  it('merges class names', () => {
+    expect(cn('px-2', false && 'hidden', 'py-2')).toBe('px-2 py-2');
+  });
+});

--- a/photos-carousel/packages/ui/src/button.tsx
+++ b/photos-carousel/packages/ui/src/button.tsx
@@ -1,0 +1,33 @@
+import type { ButtonHTMLAttributes, PropsWithChildren } from 'react';
+import { cn } from './utils.js';
+
+export type ButtonVariant = 'primary' | 'ghost';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  fullWidth?: boolean;
+}
+
+const baseStyles =
+  'inline-flex items-center justify-center rounded-full text-lg font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-60 disabled:cursor-not-allowed';
+const variants: Record<ButtonVariant, string> = {
+  primary: 'bg-blue-600 text-white hover:bg-blue-500 active:bg-blue-700',
+  ghost: 'bg-transparent text-white border border-white/40 hover:bg-white/10',
+};
+
+export function Button({
+  children,
+  className,
+  variant = 'primary',
+  fullWidth,
+  ...props
+}: PropsWithChildren<ButtonProps>) {
+  return (
+    <button
+      className={cn(baseStyles, variants[variant], fullWidth && 'w-full', className)}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/photos-carousel/packages/ui/src/hud.tsx
+++ b/photos-carousel/packages/ui/src/hud.tsx
@@ -1,0 +1,23 @@
+import type { PropsWithChildren } from 'react';
+import { cn } from './utils.js';
+
+interface HUDProps {
+  visible: boolean;
+  anchor?: 'top' | 'bottom';
+}
+
+export function HUD({ visible, anchor = 'bottom', children }: PropsWithChildren<HUDProps>) {
+  return (
+    <div
+      className={cn(
+        'pointer-events-none absolute left-0 right-0 flex justify-center transition-opacity duration-200',
+        anchor === 'bottom' ? 'bottom-0' : 'top-0',
+        visible ? 'opacity-100' : 'opacity-0',
+      )}
+    >
+      <div className="pointer-events-auto m-4 flex items-center gap-4 rounded-full bg-black/60 px-6 py-4 backdrop-blur-md">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/photos-carousel/packages/ui/src/index.ts
+++ b/photos-carousel/packages/ui/src/index.ts
@@ -1,0 +1,4 @@
+export * from './button.js';
+export * from './slider.js';
+export * from './hud.js';
+export * from './utils.js';

--- a/photos-carousel/packages/ui/src/slider.tsx
+++ b/photos-carousel/packages/ui/src/slider.tsx
@@ -1,0 +1,28 @@
+import type { ChangeEventHandler } from 'react';
+import { cn } from './utils.js';
+
+interface SliderProps {
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  label?: string;
+}
+
+export function Slider({ value, min = 0, max = 100, step = 1, onChange, label }: SliderProps) {
+  return (
+    <label className="flex w-full flex-col gap-2 text-white">
+      {label && <span className="text-sm uppercase tracking-wide text-white/60">{label}</span>}
+      <input
+        type="range"
+        className={cn('h-2 w-full appearance-none rounded-full bg-white/20 accent-blue-500')}
+        value={value}
+        onChange={onChange}
+        min={min}
+        max={max}
+        step={step}
+      />
+    </label>
+  );
+}

--- a/photos-carousel/packages/ui/src/utils.ts
+++ b/photos-carousel/packages/ui/src/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/photos-carousel/packages/ui/tsconfig.json
+++ b/photos-carousel/packages/ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "jsx": "react-jsx",
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../types" }]
+}

--- a/photos-carousel/pnpm-workspace.yaml
+++ b/photos-carousel/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/photos-carousel/tsconfig.base.json
+++ b/photos-carousel/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/photos-carousel/tsconfig.json
+++ b/photos-carousel/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./apps/web" },
+    { "path": "./apps/server" },
+    { "path": "./packages/types" },
+    { "path": "./packages/ui" }
+  ]
+}


### PR DESCRIPTION
## Summary
- set up pnpm-based monorepo with shared types and UI packages
- scaffold React PWA with tablet-friendly carousel, caching, MCP command panels, and service worker
- implement Express API with mocked Google Photos picker flow plus embedded MCP server and tests

## Testing
- pnpm install *(fails: network request blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52280181c83238fcf23ec12635ead